### PR TITLE
update rec schedule

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -83,4 +83,5 @@ const (
 	GetSchedulesByEntity              = "get_schedules_by_entity"
 	GetSchedulesByEntityDuration      = "get_schedules_by_entity_duration"
 	GetSchedulesByEntityMaxQueryCount = "get_schedules_by_entity_max_query_count"
+	UpdateRecurringSchedule           = "update_recurring_schedule"
 )

--- a/dao/dummy_schedule_dao_impl.go
+++ b/dao/dummy_schedule_dao_impl.go
@@ -213,6 +213,12 @@ func (d *DummyScheduleDaoImpl) BulkAction(app s.App, partitionId int, scheduleTi
 	return nil
 }
 
+// UpdateRecurringSchedule is a no-op stub to satisfy the ScheduleDao interface during tests.
+// It simply returns the schedule as-is without error.
+func (d *DummyScheduleDaoImpl) UpdateRecurringSchedule(schedule s.Schedule) (s.Schedule, error) {
+	return schedule, nil
+}
+
 func (d *DummyScheduleDaoImpl) UpdateRecurringScheduleStatus(schedule s.Schedule, status s.Status) (s.Schedule, error) {
 	schedule.Status = status
 	return schedule, nil

--- a/dao/schedule_dao.go
+++ b/dao/schedule_dao.go
@@ -43,4 +43,5 @@ type ScheduleDao interface {
 	GetCronSchedulesByApp(appId string, status s.Status) ([]s.Schedule, []string)
 	BulkAction(app s.App, partitionId int, scheduleTimeGroup time.Time, status []s.Status, actionType s.ActionType) error
 	UpdateRecurringScheduleStatus(schedule s.Schedule, status s.Status) (s.Schedule, error)
+	UpdateRecurringSchedule(schedule s.Schedule) (s.Schedule, error)
 }

--- a/dao/schedule_dao_impl.go
+++ b/dao/schedule_dao_impl.go
@@ -1294,6 +1294,9 @@ func (sdi *ScheduleDaoImpl) UpdateRecurringSchedule(schedule store.Schedule) (st
 	err = sdi.Session.ExecuteBatch(batch)
 	if err != nil {
 		glog.Errorf("Error: %s while updating recurring schedule: %+v", err.Error(), schedule)
+	} else {
+		glog.Infof("Updated schedule with id: %s, updated schedule: %+v", schedule.ScheduleId, schedule)
 	}
+
 	return schedule, err
 }

--- a/dao/schedule_dao_impl.go
+++ b/dao/schedule_dao_impl.go
@@ -1277,12 +1277,6 @@ func (sdi *ScheduleDaoImpl) UpdateRecurringSchedule(schedule store.Schedule) (st
 		"schedule_time_group = ? " +
 		"AND parent_schedule_id = ?"
 
-	deleteFromSchedule := "DELETE FROM schedules " +
-		"WHERE app_id = ? " +
-		"AND partition_id = ? " +
-		"AND schedule_time_group = ? " +
-		"AND schedule_id = ?"
-
 	for _, run := range runs {
 		batch.Query(
 			deleteFromRuns,

--- a/dao/schedule_dao_impl.go
+++ b/dao/schedule_dao_impl.go
@@ -1233,38 +1233,39 @@ func (sdi *ScheduleDaoImpl) UpdateRecurringScheduleStatus(schedule store.Schedul
 func (sdi *ScheduleDaoImpl) UpdateRecurringSchedule(schedule store.Schedule) (store.Schedule, error) {
 	batch := gocql.NewBatch(gocql.LoggedBatch)
 
-	for _, query := range []string{
-		"INSERT INTO recurring_schedules_by_id (" +
-			"app_id," +
-			"partition_id," +
-			"schedule_id," +
-			"payload," +
-			"callback_type," +
-			"callback_details," +
-			"cron_expression, " +
-			"status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+	// Update recurring_schedules_by_id table
+	batch.Query(
+		"UPDATE recurring_schedules_by_id SET "+
+			"payload = ?, "+
+			"callback_type = ?, "+
+			"callback_details = ?, "+
+			"cron_expression = ?, "+
+			"status = ? "+
+			"WHERE schedule_id = ?",
+		schedule.Payload,
+		schedule.GetCallBackType(),
+		schedule.GetCallbackDetails(),
+		schedule.CronExpression,
+		schedule.Status,
+		schedule.ScheduleId)
 
-		"INSERT INTO recurring_schedules_by_partition (" +
-			"app_id," +
-			"partition_id," +
-			"schedule_id," +
-			"payload," +
-			"callback_type," +
-			"callback_details," +
-			"cron_expression, " +
-			"status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-	} {
-		batch.Query(
-			query,
-			schedule.AppId,
-			schedule.PartitionId,
-			schedule.ScheduleId,
-			schedule.Payload,
-			schedule.GetCallBackType(),
-			schedule.GetCallbackDetails(),
-			schedule.CronExpression,
-			schedule.Status)
-	}
+	// Update recurring_schedules_by_partition table
+	batch.Query(
+		"UPDATE recurring_schedules_by_partition SET "+
+			"payload = ?, "+
+			"callback_type = ?, "+
+			"callback_details = ?, "+
+			"cron_expression = ?, "+
+			"status = ? "+
+			"WHERE app_id = ? AND partition_id = ? AND schedule_id = ?",
+		schedule.Payload,
+		schedule.GetCallBackType(),
+		schedule.GetCallbackDetails(),
+		schedule.CronExpression,
+		schedule.Status,
+		schedule.AppId,
+		schedule.PartitionId,
+		schedule.ScheduleId)
 
 	// Delete all future runs
 	runs, _, err := sdi.getFutureRuns(schedule.ScheduleId, -1, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,12 @@ func (s *Server) registerHTTPHandlers() {
 		}),
 	).Methods("GET")
 
+	s.router.HandleFunc("/goscheduler/schedules/{scheduleId}/updateRecurringSchedule",
+		s.monitoringMiddleware(constants.UpdateRecurringSchedule, func(w http.ResponseWriter, r *http.Request) {
+			s.service.UpdateRecurringSchedule(w, r)
+		}),
+	).Methods("PUT")
+
 	s.router.HandleFunc("/goscheduler/schedules/{scheduleId}/pause",
 		s.monitoringMiddleware(constants.PauseSchedule, func(w http.ResponseWriter, r *http.Request) {
 			s.service.PauseSchedule(w, r)

--- a/service/response.go
+++ b/service/response.go
@@ -21,7 +21,6 @@ package service
 
 import (
 	"github.com/gocql/gocql"
-	"github.com/myntra/goscheduler/store"
 	s "github.com/myntra/goscheduler/store"
 )
 
@@ -209,5 +208,5 @@ type UpdatedScheduleResponse struct {
 
 // UpdatedScheduleData contains the updated schedule
 type UpdatedScheduleData struct {
-	Schedule store.Schedule `json:"schedule"`
+	Schedule s.Schedule `json:"schedule"`
 }

--- a/service/response.go
+++ b/service/response.go
@@ -21,6 +21,7 @@ package service
 
 import (
 	"github.com/gocql/gocql"
+	"github.com/myntra/goscheduler/store"
 	s "github.com/myntra/goscheduler/store"
 )
 
@@ -198,4 +199,15 @@ type ScheduleResponse struct {
 // Used for pause and resume schedule responses
 type ScheduleData struct {
 	Schedule s.Schedule `json:"schedule"`
+}
+
+// UpdatedScheduleResponse is the response structure for the updateRecurringSchedule endpoint
+type UpdatedScheduleResponse struct {
+	Status Status              `json:"status"`
+	Data   UpdatedScheduleData `json:"data"`
+}
+
+// UpdatedScheduleData contains the updated schedule
+type UpdatedScheduleData struct {
+	Schedule store.Schedule `json:"schedule"`
 }

--- a/service/update_recurring_schedule.go
+++ b/service/update_recurring_schedule.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2023 Myntra Designs Private Limited.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gocql/gocql"
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	"github.com/myntra/goscheduler/constants"
+	er "github.com/myntra/goscheduler/error"
+	"github.com/myntra/goscheduler/store"
+	"github.com/myntra/goscheduler/util"
+)
+
+// UpdatedScheduleResponse is the response structure for the updateRecurringSchedule endpoint
+type UpdatedScheduleResponse struct {
+	Status Status              `json:"status"`
+	Data   UpdatedScheduleData `json:"data"`
+}
+
+// UpdatedScheduleData contains the updated schedule
+type UpdatedScheduleData struct {
+	Schedule store.Schedule `json:"schedule"`
+}
+
+// validateImmutableFields ensures that immutable fields (appId, scheduleId, partitionId)
+// are not being modified in the update request
+func (s *Service) validateImmutableFields(input, existing store.Schedule) error {
+	var errs []string
+
+	// Verify that appId is not being modified (only if provided in input)
+	if input.AppId != "" && input.AppId != existing.AppId {
+		glog.Infof("Cannot modify appId for schedule with id %s", existing.ScheduleId)
+		errs = append(errs, "Cannot modify appId for an existing schedule")
+	}
+
+	// Verify that scheduleId is not being modified (only if provided in input)
+	if !util.IsZeroUUID(input.ScheduleId) && input.ScheduleId != existing.ScheduleId {
+		glog.Infof("Cannot modify scheduleId for schedule with id %s", existing.ScheduleId)
+		errs = append(errs, "Cannot modify scheduleId for an existing schedule")
+	}
+
+	// Verify that partitionId is not being modified (only if provided in input)
+	if input.PartitionId != 0 && input.PartitionId != existing.PartitionId {
+		glog.Infof("Cannot modify partitionId for schedule with id %s", existing.ScheduleId)
+		errs = append(errs, "Cannot modify partitionId for an existing schedule")
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ","))
+	}
+
+	return nil
+}
+
+// UpdateRecurringSchedule updates the existing recurring schedule with new values
+// It supports updating cron expression, payload, headers, callback_type, call_back_url
+func (s *Service) UpdateRecurringSchedule(w http.ResponseWriter, r *http.Request) {
+	var errs []string
+	var input store.Schedule
+
+	vars := mux.Vars(r)
+	scheduleID := vars["scheduleId"]
+	uuid, err := gocql.ParseUUID(scheduleID)
+
+	if err != nil {
+		glog.Errorf("Cannot parse UUID from %s", scheduleID)
+		errs = append(errs, err.Error())
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, er.NewError(er.InvalidDataCode, errors.New(strings.Join(errs, ","))))
+		return
+	}
+
+	// Read and unmarshal the request body
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		glog.Errorf("UpdateRecurringSchedule: Error reading request body: %v", err)
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, er.NewError(er.UnmarshalErrorCode, err))
+		return
+	}
+
+	err = json.Unmarshal(b, &input) // input is store.Schedule
+	if err != nil {
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, er.NewError(er.UnmarshalErrorCode, err))
+		return
+	}
+
+	// First, get the schedule to ensure it exists and is recurring
+	schedule, err := s.ScheduleDao.GetSchedule(uuid)
+	if err != nil {
+		if err == gocql.ErrNotFound {
+			glog.Infof("No schedule with id :  %s found", uuid)
+			s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+			errs = append(errs, fmt.Sprintf("Schedule with id: %s not found", uuid))
+			er.Handle(w, r, er.NewError(er.DataNotFound, errors.New(strings.Join(errs, ","))))
+		} else {
+			glog.Errorf("Error fetching schedule with id %s", uuid)
+			s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+			errs = append(errs, err.Error())
+			er.Handle(w, r, er.NewError(er.DataPersistenceFailure, errors.New(strings.Join(errs, ","))))
+		}
+		return
+	}
+
+	// Check if the schedule is recurring
+	if !schedule.IsRecurring() {
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		glog.Infof("schedule with id %s is not recurring", uuid)
+		errs = append(errs, fmt.Sprintf("Schedule with id: %s is not a recurring schedule", uuid))
+		er.Handle(w, r, er.NewError(er.UnprocessableEntity, errors.New(strings.Join(errs, ","))))
+		return
+	}
+
+	// Validate immutable fields
+	if err := s.validateImmutableFields(input, schedule); err != nil {
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, er.NewError(er.InvalidDataCode, err))
+		return
+	}
+
+	// Get the app for validation
+	app, err := s.getApp(schedule.AppId)
+	if err != nil {
+		glog.Errorf("Error fetching app %s: %v", schedule.AppId, err)
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, err.(er.AppError))
+		return
+	}
+
+	// Update allowed fields
+	if input.CronExpression != "" {
+		schedule.CronExpression = input.CronExpression
+	}
+	if input.Payload != "" {
+		schedule.Payload = input.Payload
+	}
+	if input.CallbackRaw != nil {
+		schedule.CallbackRaw = input.CallbackRaw
+		// Create Callback from CallbackRaw
+		callback, err := store.CreateCallbackFromRawMessage(input.CallbackRaw)
+		if err != nil {
+			glog.Errorf("Error creating callback from raw message: %v", err)
+			s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+			errs = append(errs, err.Error())
+			er.Handle(w, r, er.NewError(er.InvalidDataCode, errors.New(strings.Join(errs, ","))))
+			return
+		}
+		schedule.Callback = callback
+	}
+
+	// Validate the updated schedule
+	validationErrs := schedule.ValidateSchedule(app, s.Config.AppLevelConfiguration)
+	if len(validationErrs) > 0 {
+		glog.Errorf("UpdateRecurringSchedule: Validation errors: %v", validationErrs)
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		er.Handle(w, r, er.NewError(er.UnprocessableEntity, errors.New(strings.Join(validationErrs, ","))))
+		return
+	}
+
+	// Update the schedule
+	updatedSchedule, err := s.ScheduleDao.UpdateRecurringSchedule(schedule)
+	if err != nil {
+		glog.Errorf("Error updating recurring schedule with id %s: %v", uuid, err)
+		s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Fail)
+		errs = append(errs, err.Error())
+		er.Handle(w, r, er.NewError(er.DataPersistenceFailure, errors.New(strings.Join(errs, ","))))
+		return
+	}
+
+	glog.V(constants.INFO).Infof("Recurring schedule with id %s updated", uuid.String())
+	s.recordRequestStatus(constants.UpdateRecurringSchedule, constants.Success)
+
+	status := Status{
+		StatusCode:    constants.SuccessCode200,
+		StatusMessage: "Recurring schedule updated successfully",
+		StatusType:    constants.Success,
+		TotalCount:    1,
+	}
+
+	data := UpdatedScheduleData{
+		Schedule: updatedSchedule,
+	}
+	_ = json.NewEncoder(w).Encode(
+		UpdatedScheduleResponse{
+			Status: status,
+			Data:   data,
+		})
+}

--- a/service/update_recurring_schedule.go
+++ b/service/update_recurring_schedule.go
@@ -53,12 +53,6 @@ func (s *Service) validateImmutableFields(inputSchedule, existing store.Schedule
 		errs = append(errs, "Cannot modify scheduleId for an existing schedule")
 	}
 
-	// Verify that partitionId is not being modified (only if provided in inputSchedule)
-	if inputSchedule.PartitionId != existing.PartitionId {
-		glog.Infof("Cannot modify partitionId for schedule with id %s", existing.ScheduleId)
-		errs = append(errs, "Cannot modify partitionId for an existing schedule")
-	}
-
 	if len(errs) > 0 {
 		return errors.New(strings.Join(errs, ","))
 	}

--- a/service/update_recurring_schedule_test.go
+++ b/service/update_recurring_schedule_test.go
@@ -33,6 +33,7 @@ func (m *MockScheduleDaoForUpdate) GetSchedule(uuid gocql.UUID) (store.Schedule,
 			AppId:          "testApp",
 			CronExpression: "", // Empty = non-recurring
 			Status:         store.Scheduled,
+			PartitionId:    0,
 		}, nil
 	case "22222222-2222-2222-2222-222222222222":
 		// U-05: Database error when fetching schedule
@@ -44,6 +45,7 @@ func (m *MockScheduleDaoForUpdate) GetSchedule(uuid gocql.UUID) (store.Schedule,
 			AppId:          "nonExistentApp",
 			CronExpression: "0 0 * * *",
 			Status:         store.Scheduled,
+			PartitionId:    0,
 		}, nil
 	case "44444444-4444-4444-4444-444444444444":
 		// U-09: For testing Cassandra timeout in UpdateRecurringSchedule
@@ -52,6 +54,7 @@ func (m *MockScheduleDaoForUpdate) GetSchedule(uuid gocql.UUID) (store.Schedule,
 			AppId:          "timeoutApp",
 			CronExpression: "0 0 * * *",
 			Payload:        `{"test": "data"}`,
+			PartitionId:    0,
 			Callback: &store.HttpCallback{
 				Type: "http",
 				Details: store.Details{
@@ -68,6 +71,7 @@ func (m *MockScheduleDaoForUpdate) GetSchedule(uuid gocql.UUID) (store.Schedule,
 			AppId:          "testApp",
 			Payload:        `{"foo":"bar"}`,
 			CronExpression: "0 0 * * *",
+			PartitionId:    0,
 			Callback: &store.HttpCallback{
 				Type: "http",
 				Details: store.Details{
@@ -258,17 +262,4 @@ func TestService_UpdateRecurringSchedule(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestScheduleDaoImpl_UpdateRecurringSchedule tests the DAO implementation
-// This would normally require a mock Cassandra session
-func TestScheduleDaoImpl_UpdateRecurringSchedule(t *testing.T) {
-	t.Run("U-08_BatchBuiltCorrectly", func(t *testing.T) {
-		// This test would verify that the batch contains exactly 3 types of statements:
-		// 1. Update recurring_schedules_by_id
-		// 2. Update recurring_schedules_by_partition
-		// 3. Delete future runs (potentially multiple)
-		// Since we can't easily mock gocql.Batch, this is more of an integration test
-		t.Skip("Requires mock Cassandra session - covered in integration tests")
-	})
 }

--- a/service/update_recurring_schedule_test.go
+++ b/service/update_recurring_schedule_test.go
@@ -1,0 +1,274 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gorilla/mux"
+	"github.com/myntra/goscheduler/dao"
+	"github.com/myntra/goscheduler/store"
+)
+
+// MockScheduleDaoForUpdate provides custom behaviour for update-recurring-schedule tests.
+type MockScheduleDaoForUpdate struct {
+	dao.DummyScheduleDaoImpl
+}
+
+var updateRecurringScheduleCallCount int
+var lastUpdateRecurringScheduleInput store.Schedule
+
+func (m *MockScheduleDaoForUpdate) GetSchedule(uuid gocql.UUID) (store.Schedule, error) {
+	switch uuid.String() {
+	case "00000000-0000-0000-0000-000000000000":
+		// U-05: Schedule not found
+		return store.Schedule{}, gocql.ErrNotFound
+	case "11111111-1111-1111-1111-111111111111":
+		// Non-recurring schedule (no cron expression)
+		return store.Schedule{
+			ScheduleId:     uuid,
+			AppId:          "testApp",
+			CronExpression: "", // Empty = non-recurring
+			Status:         store.Scheduled,
+		}, nil
+	case "22222222-2222-2222-2222-222222222222":
+		// U-05: Database error when fetching schedule
+		return store.Schedule{}, errors.New("database connection error")
+	case "33333333-3333-3333-3333-333333333333":
+		// U-04: Schedule exists but app not found
+		return store.Schedule{
+			ScheduleId:     uuid,
+			AppId:          "nonExistentApp",
+			CronExpression: "0 0 * * *",
+			Status:         store.Scheduled,
+		}, nil
+	case "44444444-4444-4444-4444-444444444444":
+		// U-09: For testing Cassandra timeout in UpdateRecurringSchedule
+		return store.Schedule{
+			ScheduleId:     uuid,
+			AppId:          "timeoutApp",
+			CronExpression: "0 0 * * *",
+			Payload:        `{"test": "data"}`,
+			Callback: &store.HttpCallback{
+				Type: "http",
+				Details: store.Details{
+					Url:    "http://example.com",
+					Method: "POST",
+				},
+			},
+			Status: store.Scheduled,
+		}, nil
+	default:
+		// U-01: Valid recurring schedule for happy path
+		return store.Schedule{
+			ScheduleId:     uuid,
+			AppId:          "testApp",
+			Payload:        `{"foo":"bar"}`,
+			CronExpression: "0 0 * * *",
+			Callback: &store.HttpCallback{
+				Type: "http",
+				Details: store.Details{
+					Url:    "http://example.com",
+					Method: "GET",
+				},
+			},
+			Status: store.Scheduled,
+		}, nil
+	}
+}
+
+func (m *MockScheduleDaoForUpdate) UpdateRecurringSchedule(schedule store.Schedule) (store.Schedule, error) {
+	updateRecurringScheduleCallCount++
+	lastUpdateRecurringScheduleInput = schedule
+
+	// U-09: Simulate Cassandra timeout
+	if schedule.AppId == "timeoutApp" {
+		return store.Schedule{}, gocql.ErrTimeoutNoResponse
+	}
+
+	return schedule, nil
+}
+
+// MockClusterDaoForUpdate to handle app-related test cases
+type MockClusterDaoForUpdate struct {
+	dao.DummyClusterDaoImpl
+}
+
+func (m *MockClusterDaoForUpdate) GetApp(appId string) (store.App, error) {
+	switch appId {
+	case "nonExistentApp":
+		// U-04: App not found
+		return store.App{}, gocql.ErrNotFound
+	case "testApp", "timeoutApp":
+		return store.App{
+			AppId:      appId,
+			Active:     true,
+			Partitions: 1,
+		}, nil
+	default:
+		return store.App{}, errors.New("unexpected app id")
+	}
+}
+
+func setupMocksForUpdateRecurringSchedule() *Service {
+	sh := setupMocks()
+	sh.ScheduleDao = &MockScheduleDaoForUpdate{}
+	sh.ClusterDao = &MockClusterDaoForUpdate{}
+	updateRecurringScheduleCallCount = 0
+	return sh
+}
+
+func TestService_UpdateRecurringSchedule(t *testing.T) {
+	service := setupMocksForUpdateRecurringSchedule()
+
+	tests := []struct {
+		name        string
+		testID      string
+		scheduleID  string
+		body        []byte
+		wantStatus  int
+		description string
+	}{
+		{
+			name:        "U-01_HappyPath",
+			testID:      "U-01",
+			scheduleID:  "55555555-5555-5555-5555-555555555555",
+			body:        []byte(`{"cronExpression":"*/10 * * * *","payload":"{\"updated\":\"value\"}"}`),
+			wantStatus:  http.StatusOK,
+			description: "Valid JSON; schedule exists & is recurring",
+		},
+		{
+			name:        "U-02_MalformedJSON",
+			testID:      "U-02",
+			scheduleID:  "55555555-5555-5555-5555-555555555555",
+			body:        []byte(`{bad json`),
+			wantStatus:  http.StatusBadRequest,
+			description: "Malformed JSON body",
+		},
+		{
+			name:        "U-05_ScheduleNotFound",
+			testID:      "U-05",
+			scheduleID:  "00000000-0000-0000-0000-000000000000",
+			body:        []byte(`{}`),
+			wantStatus:  http.StatusNotFound,
+			description: "Schedule does not exist",
+		},
+		{
+			name:        "NonRecurringSchedule",
+			testID:      "Related",
+			scheduleID:  "11111111-1111-1111-1111-111111111111",
+			body:        []byte(`{"cronExpression":"*/10 * * * *"}`),
+			wantStatus:  http.StatusUnprocessableEntity,
+			description: "Schedule is not recurring",
+		},
+		{
+			name:        "U-05_DatabaseError",
+			testID:      "U-05",
+			scheduleID:  "22222222-2222-2222-2222-222222222222",
+			body:        []byte(`{}`),
+			wantStatus:  http.StatusInternalServerError,
+			description: "DAO failure when reading schedule",
+		},
+		{
+			name:        "U-04_AppNotFound",
+			testID:      "U-04",
+			scheduleID:  "33333333-3333-3333-3333-333333333333",
+			body:        []byte(`{}`),
+			wantStatus:  http.StatusBadRequest,
+			description: "App not found",
+		},
+		{
+			name:        "U-03_AppIdMismatch",
+			testID:      "U-03",
+			scheduleID:  "55555555-5555-5555-5555-555555555555",
+			body:        []byte(`{"appId":"differentApp","cronExpression":"*/10 * * * *"}`),
+			wantStatus:  http.StatusBadRequest,
+			description: "AppId in body doesn't match schedule's appId",
+		},
+		{
+			name:        "U-06_InvalidCronExpression",
+			testID:      "U-06",
+			scheduleID:  "55555555-5555-5555-5555-555555555555",
+			body:        []byte(`{"cronExpression":"* * *"}`),
+			wantStatus:  http.StatusUnprocessableEntity,
+			description: "Invalid cron expression",
+		},
+		{
+			name:        "U-09_CassandraTimeout",
+			testID:      "U-09",
+			scheduleID:  "44444444-4444-4444-4444-444444444444",
+			body:        []byte(`{"cronExpression":"*/10 * * * *"}`),
+			wantStatus:  http.StatusInternalServerError,
+			description: "Cassandra timeout during update",
+		},
+		{
+			name:        "InvalidScheduleUUID",
+			testID:      "Related",
+			scheduleID:  "not-a-valid-uuid",
+			body:        []byte(`{}`),
+			wantStatus:  http.StatusBadRequest,
+			description: "Invalid UUID format",
+		},
+		{
+			name:        "UpdateCallbackType",
+			testID:      "Related",
+			scheduleID:  "55555555-5555-5555-5555-555555555555",
+			body:        []byte(`{"callback":{"type":"http","details":{"url":"http://newurl.com","method":"POST","headers":{"X-Custom":"header"}}}}`),
+			wantStatus:  http.StatusOK,
+			description: "Update callback_type and details",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset counter for each test
+			updateRecurringScheduleCallCount = 0
+
+			req, err := http.NewRequest("PUT", "/goscheduler/schedules/{scheduleId}/updateRecurringSchedule", bytes.NewBuffer(tc.body))
+			if err != nil {
+				t.Fatalf("could not create request: %v", err)
+			}
+			req = mux.SetURLVars(req, map[string]string{"scheduleId": tc.scheduleID})
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(service.UpdateRecurringSchedule)
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tc.wantStatus {
+				t.Errorf("%s: unexpected status code: got %v, want %v. Description: %s",
+					tc.testID, status, tc.wantStatus, tc.description)
+				t.Logf("Response body: %s", rr.Body.String())
+			}
+
+			// Additional validations for specific test cases
+			if tc.testID == "U-01" && updateRecurringScheduleCallCount != 1 {
+				t.Errorf("U-01: Expected UpdateRecurringSchedule to be called once, but was called %d times",
+					updateRecurringScheduleCallCount)
+			}
+
+			if tc.name == "UpdateCallbackType" && updateRecurringScheduleCallCount == 1 {
+				// Verify callback was properly updated
+				if lastUpdateRecurringScheduleInput.GetCallBackType() != "http" {
+					t.Errorf("Expected callback type to be 'http', got '%s'",
+						lastUpdateRecurringScheduleInput.GetCallBackType())
+				}
+			}
+		})
+	}
+}
+
+// TestScheduleDaoImpl_UpdateRecurringSchedule tests the DAO implementation
+// This would normally require a mock Cassandra session
+func TestScheduleDaoImpl_UpdateRecurringSchedule(t *testing.T) {
+	t.Run("U-08_BatchBuiltCorrectly", func(t *testing.T) {
+		// This test would verify that the batch contains exactly 3 types of statements:
+		// 1. Update recurring_schedules_by_id
+		// 2. Update recurring_schedules_by_partition
+		// 3. Delete future runs (potentially multiple)
+		// Since we can't easily mock gocql.Batch, this is more of an integration test
+		t.Skip("Requires mock Cassandra session - covered in integration tests")
+	})
+}

--- a/store/schedule.go
+++ b/store/schedule.go
@@ -214,6 +214,26 @@ func convertCallbackToRaw(s *Schedule) ([]byte, error) {
 	return nil, errors.New("nil callback object")
 }
 
+// CreateCallbackFromRawMessage creates a Callback from a json.RawMessage
+func CreateCallbackFromRawMessage(rawMessage json.RawMessage) (Callback, error) {
+	var httpCallback HttpCallback
+	var airbusCallback AirbusCallback
+
+	// First try to unmarshal as HTTPCallback
+	err := json.Unmarshal(rawMessage, &httpCallback)
+	if err == nil {
+		return &httpCallback, nil // Return pointer - required for interface implementation
+	}
+
+	// Then try to unmarshal as AirbusCallback
+	err = json.Unmarshal(rawMessage, &airbusCallback)
+	if err == nil {
+		return &airbusCallback, nil // Return pointer - required for interface implementation
+	}
+
+	return nil, errors.New("invalid callback format")
+}
+
 func (s Schedule) IsRecurring() bool {
 	return len(s.CronExpression) > 0
 }


### PR DESCRIPTION
This PR introduces an endpoint to update existing recurring schedules, allowing changes to cron expression, payload, callback type, and headers. When a schedule is updated, all future runs are deleted to maintain consistency.